### PR TITLE
setup.py: Remove download_url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(name='chevron',
       author='noah morrison',
       author_email='noah@morrison.ph',
       url='',
-      download_url='/tarball/0.7.1',
       packages=['chevron'],
       entry_points={
           'console_scripts': ['chevron=chevron:cli_main']


### PR DESCRIPTION
IIRC download_url is not so useful anymore because pip much prefers to install from PyPI and will refuse to download from external places without special options. 

And that URL was not valid anyway.