### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py26, py27, py33, py34, pypy, pypy3, flake8
+
+[testenv]
+commands = python {toxinidir}/test_spec.py
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 chevron


### PR DESCRIPTION
[Tox](https://testrun.org/tox/latest/) lets you run your tests with multiple versions of Python.

```
$ pip install tox
...
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  pypy3: commands succeeded
ERROR:   flake8: commands failed
```