### PR TITLE
correct error for badly closed tag

### DIFF
--- a/chevron/tokenizer.py
+++ b/chevron/tokenizer.py
@@ -79,7 +79,11 @@ def parse_tag(template, l_del, r_del):
     }
 
     # Get the tag
-    tag, template = template.split(r_del, 1)
+    try:
+        tag, template = template.split(r_del, 1)
+    except ValueError:
+        raise ChevronError('unclosed tag '
+                           'at line {0}'.format(_CURRENT_LINE))
 
     # Find the type meaning of the first character
     tag_type = tag_types.get(tag[0], 'variable')

--- a/test_spec.py
+++ b/test_spec.py
@@ -194,6 +194,14 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_closing_tag_only(self):
+        args = {
+            'template': '{{ foo } bar',
+            'data': {'foo': 'xx'}
+        }
+
+        self.assertRaises(chevron.ChevronError, chevron.render, **args)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
The test kind of explains it. Without a properly closed tag a `ValueError` is raised, not `ChevronError`.