### PR TITLE
fix line numbers in errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pip-log.txt
 
 # Mr Developer
 .mr.developer.cfg
+.idea/

--- a/chevron/tokenizer.py
+++ b/chevron/tokenizer.py
@@ -160,6 +160,9 @@ def tokenize(template, def_ldel='{{', def_rdel='}}'):
     the literal itself.
     """
 
+    global _CURRENT_LINE, _LAST_TAG_LINE
+    _CURRENT_LINE = 1
+    _LAST_TAG_LINE = None
     # If the template is a file-like object then read it
     try:
         template = template.read()

--- a/test_spec.py
+++ b/test_spec.py
@@ -202,6 +202,22 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertRaises(chevron.ChevronError, chevron.render, **args)
 
+    def test_current_line_rest(self):
+        args = {
+            'template': 'first line\nsecond line\n {{ foo } bar',
+            'data': {'foo': 'xx'}
+        }
+
+        self.assertRaisesRegexp(chevron.ChevronError,
+                                'unclosed tag at line 3',
+                                chevron.render, **args)
+        self.assertRaisesRegexp(chevron.ChevronError,
+                                'unclosed tag at line 3',
+                                chevron.render, **args)
+        self.assertRaisesRegexp(chevron.ChevronError,
+                                'unclosed tag at line 3',
+                                chevron.render, **args)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":

--- a/test_spec.py
+++ b/test_spec.py
@@ -1,11 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import unittest
 import os
 import json
 
 import chevron
+
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 SPECS_PATH = os.path.join('spec', 'specs')
 SPECS = [path for path in os.listdir(SPECS_PATH) if path.endswith('.json')]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py26, py27, py32, py33, py34, py35, pypy, flake8
 
 [testenv]
-deps = coverage
+deps = coverage,unitest2
 commands =
     coverage run --source={toxinidir}/chevron {toxinidir}/test_spec.py
     coverage report -m


### PR DESCRIPTION
Just integrating #21, and "snap", this happened. :disappointed:

Previously the line number in errors continued to increment for repeated calls to `chevron.render`.