### PR TITLE
Handling missing opening tag

### DIFF
--- a/chevron/tokenizer.py
+++ b/chevron/tokenizer.py
@@ -208,7 +208,13 @@ def tokenize(template, def_ldel='{{', def_rdel='}}'):
         elif tag_type == 'end':
             # Then check to see if the last opened section
             # is the same as us
-            last_section = open_sections.pop()
+            try:
+                last_section = open_sections.pop()
+            except IndexError:
+                raise ChevronError('Trying to close tag "{0}"\n'
+                                   'Looks like it was not opened.\n'
+                                   'line {1}'
+                                   .format(tag_key, _CURRENT_LINE + 1))
             if tag_key != last_section:
                 # Otherwise we need to complain
                 raise ChevronError('Trying to close tag "{0}"\n'

--- a/test_spec.py
+++ b/test_spec.py
@@ -215,6 +215,19 @@ class ExpandedCoverage(unittest.TestCase):
             except chevron.ChevronError as error:
                 self.assertEqual(error.msg, 'unclosed tag at line 3')
 
+    def test_no_opening_tag(self):
+        args = {
+            'template': 'oops, no opening tag {{/ closing_tag }}',
+            'data': {'foo': 'xx'}
+        }
+
+        try:
+            chevron.render(**args)
+        except chevron.ChevronError as error:
+            self.assertEqual(error.msg, 'Trying to close tag "closing_tag"\n'
+                                        'Looks like it was not opened.\n'
+                                        'line 2')
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
Pretty self-explanatory: the tokenizer wasn't handling closing tags (e.g: {{/ one_boolean}} ) without enough opening tags; the .pop() was raising IndexError: pop from empty list

Feel free to change the error message :)