### PR TITLE
Python 2.6, 2.7, 3.2-3.6 in README.md, setup.py, and tox.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you find a test that chevron does not pass, please [report it.](https://githu
 
 ### chevron is Python 2 and 3 compatible ###
 
-Python 2.6, 2.7, 3.2, 3.3, and 3.4 are all tested by travis.
+Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, and 3.6 are all tested by travis.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(name='chevron',
           'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
-
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Topic :: Text Processing :: Markup'
       ]
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy, flake8
+envlist = py26, py27, py32, py33, py34, py35, py36, pypy, flake8
 
 [testenv]
 deps = coverage


### PR DESCRIPTION
Why not drop support for Python versions that are already EOL such as 2.6, 3.2, and 3.3?
* https://docs.python.org/devguide/index.html#branchstatus