### PR TITLE
fix(renderer): allow unicode for no-escape variables

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -203,7 +203,10 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a no html escape tag
         elif tag == 'no escape':
             # Just lookup the key and add it
-            output += str(_get_key(key, scopes))
+            thing = _get_key(key, scopes)
+            if type(thing) != unicode:
+                thing = unicode(str(thing), 'utf-8')
+            output += thing
 
         # If we're a section tag
         elif tag == 'section':

--- a/tests/data.json
+++ b/tests/data.json
@@ -12,5 +12,6 @@
   "scope": {
       "test": "new test"
   },
-  "unicode": "(╯°□°）╯︵ ┻━┻"
+  "unicode": "(╯°□°）╯︵ ┻━┻",
+  "unicode_html": "<a>(╯°□°）╯︵ ┻━┻"
 }

--- a/tests/test.mustache
+++ b/tests/test.mustache
@@ -140,3 +140,10 @@ unicode test (partial)
 ===
 (╯°□°）╯︵ ┻━┻
 ===
+
+unicode test (no-escape)
+===
+{{& unicode_html }}
+===
+<a>(╯°□°）╯︵ ┻━┻
+===

--- a/tests/test.rendered
+++ b/tests/test.rendered
@@ -124,3 +124,10 @@ unicode test (partial)
 ===
 (╯°□°）╯︵ ┻━┻
 ===
+
+unicode test (no-escape)
+===
+<a>(╯°□°）╯︵ ┻━┻
+===
+<a>(╯°□°）╯︵ ┻━┻
+===


### PR DESCRIPTION
## Issue
See Issue https://github.com/noahmorrison/chevron/issues/28 for more details.

## Changes
- Add unicode parsing for 'no-escape' case
- Add test case for parsing unicode  without escaping HTML