### PR TITLE
add frontmatter in commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ usage: chevron [-h] [-v] [-d DATA] [-p PARTIALS_PATH] [-e PARTIALS_EXT]
                template
 
 positional arguments:
-  template              The mustache file
+  template              The mustache file, "-" to read from stdin
 
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  -d DATA, --data DATA  The json data file
+  -d DATA, --data DATA  The json data file, if you do not pass data, you can
+                        use frontmatter in template
   -p PARTIALS_PATH, --path PARTIALS_PATH
                         The directory where your partials reside
   -e PARTIALS_EXT, --ext PARTIALS_EXT

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(name='chevron',
       entry_points={
           'console_scripts': ['chevron=chevron:cli_main']
       },
+      install_requires=[
+          'python-frontmatter'
+      ],
 
       classifiers=[
           'Development Status :: 4 - Beta',

--- a/test_spec.py
+++ b/test_spec.py
@@ -8,7 +8,10 @@ import json
 import chevron
 
 SPECS_PATH = os.path.join('spec', 'specs')
-SPECS = [path for path in os.listdir(SPECS_PATH) if path.endswith('.json')]
+if os.path.exists(SPECS_PATH):
+    SPECS = [path for path in os.listdir(SPECS_PATH) if path.endswith('.json')]
+else:
+    SPECS = []
 STACHE = chevron.render
 
 
@@ -227,6 +230,21 @@ class ExpandedCoverage(unittest.TestCase):
             self.assertEqual(error.msg, 'Trying to close tag "closing_tag"\n'
                                         'Looks like it was not opened.\n'
                                         'line 2')
+
+    def test_frontmatter(self):
+        from chevron.main import main
+        from io import StringIO
+        from textwrap import dedent
+
+        result = main("-", stdin=StringIO(unicode(dedent("""
+        ---
+        name: world
+        ---
+        hello {{ name }}!
+        """))))
+
+        self.assertEqual(result, "hello world!")
+
 
 
 # Run unit tests from command line


### PR DESCRIPTION
Hi @noahmorrison ,

I have also added the feature to use frontmatter in commandline.  If you do not pass --data via commandline the script tries to read frontmatter from template to get data.

Best regards, Kiwi