### PR TITLE
Supporting Partial File Without File Extension

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -90,7 +90,7 @@ def _get_partial(name, partials_dict, partials_path, partials_ext):
         # Nope...
         try:
             # Maybe it's in the file system
-            path = partials_path + '/' + name + '.' + partials_ext
+            path = partials_path + '/' + name + ('.' + partials_ext if partials_ext else '')
             with open(path, 'r') as partial:
                 return partial.read()
 


### PR DESCRIPTION
Change made to function `_get_partial`:
From `path = partials_path + '/' + name + '.' + partials_ext` to `path = partials_path + '/' + name + ('.' + partials_ext if partials_ext else '')`.