### PR TITLE
Fix flake8-reported style issues

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -98,10 +98,12 @@ def _get_partial(name, partials_dict, partials_path, partials_ext):
             # Alright I give up on you
             return ''
 
+
 #
 # The main rendering function
 #
 g_token_cache = {}
+
 
 def render(template='', data={}, partials_path='.', partials_ext='mustache',
            partials_dict={}, padding=0, def_ldel='{{', def_rdel='}}',
@@ -282,7 +284,8 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                         tags_with_same_key += 1
                     if tag == ('end', key):
                         tags_with_same_key -= 1
-                        if tags_with_same_key < 0: break
+                        if tags_with_same_key < 0:
+                            break
                     tags.append(tag)
 
                 # For every item in the scope

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ except (ImportError, RuntimeError):
     readme = ''
 
 
-
 setup(name='chevron',
       version=chevron.metadata.version,
       license='MIT',


### PR DESCRIPTION
For the records, these are the reported and now fixed issues:
```
./setup.py:19:1: E303 too many blank lines (3)
./chevron/renderer.py:104:1: E305 expected 2 blank lines after class or function definition, found 1
./chevron/renderer.py:106:1: E302 expected 2 blank lines, found 1
./chevron/renderer.py:285:50: E701 multiple statements on one line (colon)
```
