### PR TITLE
Fix the rendering of lambdas

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -251,7 +251,8 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                                 'end': '/',
                                 'partial': '>',
                                 'set delimiter': '=',
-                                'no escape': '&'
+                                'no escape': '&',
+                                'variable': ''
                             }[tag_type], tag_key, def_rdel)
 
                 g_token_cache[text] = tags


### PR DESCRIPTION
Variables are the most common tag types, yet they were not handled
during the generation of template text for lambda scopes.