### PR TITLE
Add MANIFEST.in to ensure that README.md is found by setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
On latest master / tag 0.13.1, tox didn't run for me locally. Error log below:
```
$ rm -rf .tox/ chevron.egg-info/
$ tox -e py34
GLOB sdist-make: chevron/setup.py
py34 create: chevron/.tox/py34
py34 installdeps: coverage
py34 inst: chevron/.tox/dist/chevron-0.13.1.zip
ERROR: invocation failed (exit code 1), logfile: chevron/.tox/py34/log/py34-2.log
ERROR: actionid: py34
msg: installpkg
cmdargs: ['chevron/.tox/py34/bin/pip', 'install', 'chevron/.tox/dist/chevron-0.13.1.zip']

Processing ./.tox/dist/chevron-0.13.1.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/k7/fsl254_s2jv8c63g1wc141rr0000gn/T/pip-req-build-w5wgyv1z/setup.py", line 11, in <module>
        with open('README.md') as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/k7/fsl254_s2jv8c63g1wc141rr0000gn/T/pip-req-build-w5wgyv1z/

py34 installed: coverage==4.5.1
___________________________________________________________________________ summary ___________________________________________________________________________
ERROR:   py34: InvocationError: chevron/.tox/py34/bin/pip install chevron/.tox/dist/chevron-0.13.1.zip (see chevron/.tox/py34/log/py34-2.log)

$ source .tox/py34/bin/activate
$ pip --version
pip 18.1 from chevron/.tox/py34/lib/python3.4/site-packages/pip (python 3.4)
```

After adding MANIFEST.in, the error goes away and tox passes.

As Travis CI runs fine, it must be some pip version difference.