### PR TITLE
Improvements to coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.py[co]
 
+# Code coverage
+coverage.xml
+
 # Jython
 *.class
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/chevron.svg)](https://badge.fury.io/py/chevron)
 [![Build Status](https://travis-ci.org/noahmorrison/chevron.svg?branch=master)](https://travis-ci.org/noahmorrison/chevron)
-[![Coverage Status](https://img.shields.io/coveralls/noahmorrison/chevron.svg)](https://coveralls.io/r/noahmorrison/chevron?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/noahmorrison/chevron/badge.svg?branch=master)](https://coveralls.io/github/noahmorrison/chevron?branch=master)
 
 A python implementation of the [mustache templating language](http://mustache.github.io).
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from .chevron.main import main, cli_main
 from .chevron.renderer import render
+from .chevron.tokenizer import ChevronError
 
-__all__ = ['main', 'render', 'cli_main']
+__all__ = ['main', 'render', 'cli_main', 'ChevronError']

--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -211,7 +211,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a literal tag
         elif tag == 'literal':
             # Add padding to the key and add it to the output
-            if not isinstance(key, unicode_type):
+            if not isinstance(key, unicode_type): # python 2
                 key = unicode(key, 'utf-8')
             output += key.replace('\n', '\n' + padding)
 

--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -211,7 +211,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a literal tag
         elif tag == 'literal':
             # Add padding to the key and add it to the output
-            if not isinstance(key, unicode_type): # python 2
+            if not isinstance(key, unicode_type):  # python 2
                 key = unicode(key, 'utf-8')
             output += key.replace('\n', '\n' + padding)
 

--- a/test_spec.py
+++ b/test_spec.py
@@ -333,6 +333,28 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_callable_4(self):
+        '''Test render of partial inside lambda
+        '''
+
+        def function(content, render):
+            return render(content)
+
+        args = {
+            'template': '{{#function}}{{>partial}}{{!comment}}{{/function}}',
+            'partials_dict': {
+                'partial': 'partial content',
+            },
+            'data': {
+                'function': function,
+            }
+        }
+
+        result = chevron.render(**args)
+        expected = 'partial content'
+
+        self.assertEqual(result, expected)
+
     # https://github.com/noahmorrison/chevron/issues/35
     def test_custom_falsy(self):
         class CustomData(dict):

--- a/test_spec.py
+++ b/test_spec.py
@@ -333,6 +333,46 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    # https://github.com/noahmorrison/chevron/issues/35
+    def test_custom_falsy(self):
+        class CustomData(dict):
+            class LowercaseBool:
+                _CHEVRON_return_scope_when_falsy = True
+
+                def __init__(self, value):
+                    self.value = value
+
+                def __bool__(self):
+                    return self.value
+                __nonzero__ = __bool__
+
+                def __str__(self):
+                    if self.value:
+                        return 'true'
+                    return 'false'
+
+            def __getitem__(self, key):
+                item = dict.__getitem__(self, key)
+                if isinstance(item, dict):
+                    return CustomData(item)
+                if isinstance(item, bool):
+                    return self.LowercaseBool(item)
+                return item
+
+        args = {
+            'data': CustomData({ 
+                'truthy': True,
+                'falsy': False,
+            }),
+            'template': '{{ truthy }} {{ falsy }}',
+        }
+
+
+        result = chevron.render(**args)
+        expected = 'true false'
+
+        self.assertEqual(result, expected)
+
     # https://github.com/noahmorrison/chevron/issues/39
     def test_nest_loops_with_same_key(self):
         args = {

--- a/test_spec.py
+++ b/test_spec.py
@@ -382,13 +382,12 @@ class ExpandedCoverage(unittest.TestCase):
                 return item
 
         args = {
-            'data': CustomData({ 
+            'data': CustomData({
                 'truthy': True,
                 'falsy': False,
             }),
             'template': '{{ truthy }} {{ falsy }}',
         }
-
 
         result = chevron.render(**args)
         expected = 'true false'


### PR DESCRIPTION
The test coverage got a little out of date. The commits are pretty discrete, but here's a list of what I fixed:

- The coverage badge broke
- Pytest wouldn't pass (probably indicated a bigger problem, but that's how I was running coverage locally)
- Issue #35 (custom falsy) wasn't tested
- Some unicode handling wasn't marked as Python2
- Lambda's were not completely tested