### PR TITLE
Fix indentation when iterating in scope

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -311,6 +311,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                     # Append it as the most recent scope and render
                     new_scope = [thing] + scopes
                     rend = render(template=tags, scopes=new_scope,
+                                  padding=padding,
                                   partials_path=partials_path,
                                   partials_ext=partials_ext,
                                   partials_dict=partials_dict,

--- a/test_spec.py
+++ b/test_spec.py
@@ -435,6 +435,23 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_iterator_scope_indentation(self):
+        args = {
+            'data': {
+                'thing': ['foo', 'bar', 'baz'],
+            },
+            'template': '{{> count }}',
+            'partials_dict': {
+                'count': '    {{> iter_scope }}',
+                'iter_scope': 'foobar\n{{#thing}}\n {{.}}\n{{/thing}}'
+            }
+        }
+
+        result = chevron.render(**args)
+        expected = '    foobar\n     foo\n     bar\n     baz\n'
+
+        self.assertEqual(result, expected)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
I think related to this: https://github.com/noahmorrison/chevron/issues/49

When iterating over a scope in a partial the indentation is forgotten.

Template in testcase.

Expected output:

foobar is indented 4 spaces, the others 5.
```
    foobar
     foo
     bar
     baz
```

Current actual output:

foobar is indented 4 spaces, foo 5, the rest 1.
```
    foobar
     foo
 bar
 baz

```