### PR TITLE
Add command-line option to warn on undefined keys

### DIFF
--- a/chevron/main.py
+++ b/chevron/main.py
@@ -79,7 +79,7 @@ def cli_main():
                         default='}}')
 
     parser.add_argument('-w', '--warn', dest='warn',
-                        help='Warn on undefined template substitutions',
+                        help='Print a warning to stderr for each undefined template key encountered',
                         action='store_true')
 
 

--- a/chevron/main.py
+++ b/chevron/main.py
@@ -78,6 +78,11 @@ def cli_main():
                         help='The default right delimiter, "}}" by default.',
                         default='}}')
 
+    parser.add_argument('-w', '--warn', dest='warn',
+                        help='Warn on undefined template substitutions',
+                        action='store_true')
+
+
     args = vars(parser.parse_args())
 
     try:

--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -47,7 +47,7 @@ def _html_escape(string):
     return string
 
 
-def _get_key(key, scopes):
+def _get_key(key, scopes, warn=False):
     """Get a key from the current scope"""
 
     # If the key is a dot
@@ -93,6 +93,10 @@ def _get_key(key, scopes):
             pass
 
     # We couldn't find the key in any of the scopes
+
+    if warn:
+        sys.stderr.write("Could not find key '%s'" % key)
+
     return ''
 
 
@@ -123,7 +127,7 @@ g_token_cache = {}
 
 def render(template='', data={}, partials_path='.', partials_ext='mustache',
            partials_dict={}, padding='', def_ldel='{{', def_rdel='}}',
-           scopes=None):
+           scopes=None, warn=False):
     """Render a mustache template.
 
     Renders a mustache template with a data scope and partial capability.
@@ -166,6 +170,8 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                      ("}}" by default, as in spec compliant mustache)
 
     scopes        -- The list of scopes that get_key will look through
+
+    warn -- Issue a warning to stderr when a template substitution isn't found in the data
 
 
     Returns:
@@ -218,7 +224,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a variable tag
         elif tag == 'variable':
             # Add the html escaped key to the output
-            thing = _get_key(key, scopes)
+            thing = _get_key(key, scopes, warn=warn)
             if thing is True and key == '.':
                 # if we've coerced into a boolean by accident
                 # (inverted tags do this)
@@ -231,7 +237,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a no html escape tag
         elif tag == 'no escape':
             # Just lookup the key and add it
-            thing = _get_key(key, scopes)
+            thing = _get_key(key, scopes, warn=warn)
             if not isinstance(thing, unicode_type):
                 thing = unicode(str(thing), 'utf-8')
             output += thing
@@ -239,7 +245,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're a section tag
         elif tag == 'section':
             # Get the sections scope
-            scope = _get_key(key, scopes)
+            scope = _get_key(key, scopes, warn=warn)
 
             # If the scope is a callable (as described in
             # https://mustache.github.io/mustache.5.html)
@@ -328,7 +334,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         # If we're an inverted section
         elif tag == 'inverted section':
             # Add the flipped scope to the scopes
-            scope = _get_key(key, scopes)
+            scope = _get_key(key, scopes, warn=warn)
             scopes.insert(0, not scope)
 
         # If we're a partial

--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import io
+from os import linesep
 
 try:
     from collections.abc import Sequence, Iterator, Callable
@@ -95,7 +96,7 @@ def _get_key(key, scopes, warn=False):
     # We couldn't find the key in any of the scopes
 
     if warn:
-        sys.stderr.write("Could not find key '%s'" % key)
+        sys.stderr.write("Could not find key '%s'%s" % (key, linesep))
 
     return ''
 


### PR DESCRIPTION
Just a little something I find convenient when diagnosing my templates. if the `-w` or `--warn` flag is provided on the command line, or `warn=True` to `render`, a simple warning will be printed to stderr on each key referenced by the template but not defined in the data.