### PR TITLE
allow bypassing html_escaping

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -123,7 +123,7 @@ g_token_cache = {}
 
 def render(template='', data={}, partials_path='.', partials_ext='mustache',
            partials_dict={}, padding='', def_ldel='{{', def_rdel='}}',
-           scopes=None):
+           scopes=None, escape_html=True):
     """Render a mustache template.
 
     Renders a mustache template with a data scope and partial capability.
@@ -226,7 +226,10 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                 thing = scopes[1]
             if not isinstance(thing, unicode_type):
                 thing = unicode(str(thing), 'utf-8')
-            output += _html_escape(thing)
+            if escape_html:
+                output += _html_escape(thing)
+            else:
+                output += thing
 
         # If we're a no html escape tag
         elif tag == 'no escape':

--- a/test_spec.py
+++ b/test_spec.py
@@ -435,6 +435,24 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_no_html_escaping(self):
+        args = {
+            'template': '#|{{quote}}{{bt}}{{lt}}',
+            'data': {
+                "quote": '"',
+                "bt": ">",
+                "lt": "<",
+            },
+        }
+
+        result = chevron.render(**args, escape_html=False)
+        expected = '#|"><'
+        self.assertEqual(result, expected)
+
+        result = chevron.render(**args)
+        expected = '#|&quot;&gt;&lt;'
+        self.assertEqual(result, expected)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
In some cases mustache/chevron can be used to template strings that
are not html, for example templating SQL or other languages/strings like
`markdown`.