### PR TITLE
Defaulting to yaml.FullLoader with hidden cli arg to resolve GH-78

### DIFF
--- a/chevron/main.py
+++ b/chevron/main.py
@@ -13,7 +13,7 @@ except (ValueError, SystemError):  # python 2
 
 def main(template, data=None, **kwargs):
     with io.open(template, 'r', encoding='utf-8') as template_file:
-        yaml_loader = kwargs.pop('yaml_loader', None) or 'FullLoader'
+        yaml_loader = kwargs.pop('yaml_loader', None) or 'SafeLoader'
 
         if data is not None:
             with io.open(data, 'r', encoding='utf-8') as data_file:

--- a/chevron/main.py
+++ b/chevron/main.py
@@ -33,8 +33,8 @@ def main(template, data={}, **kwargs):
 def _load_data(file, yaml_loader):
     try:
         import yaml
-        loader = getattr(yaml, yaml_loader)
-        return yaml.load(file, Loader=loader)
+        loader = getattr(yaml, yaml_loader)  # not tested
+        return yaml.load(file, Loader=loader)  # not tested
     except ImportError:
         import json
         return json.load(file)


### PR DESCRIPTION
I considered a couple of options but this seemed to be a good solution for GH-78. It preserves support for yaml data files when pyyaml is installed and defaults to the yaml.FullLoader for parsing. A cli arg allows the cli user to specify a different loader. This cli arg is hidden since it is quite an edge case and support for yaml data files itself is also not mentioned.

I look forward to receiving feedback and updating the PR accordingly.