### PR TITLE
Use getattr instead of _asdict/__getitem__

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -67,16 +67,10 @@ def _get_key(key, scopes, warn=False):
                     scope = scope[child]
                 except (TypeError, AttributeError):
                     try:
-                        # Try namedtuple (which does not have __dict__ in
-                        # Python 3: https://bugs.python.org/issue24931)
-                        scope = scope._asdict()[child]
+                        scope = getattr(scope, child)
                     except (TypeError, AttributeError):
-                        try:
-                            # Try the dictionary (Complex types)
-                            scope = scope.__dict__[child]
-                        except (TypeError, AttributeError):
-                            # Try as a list
-                            scope = scope[int(child)]
+                        # Try as a list
+                        scope = scope[int(child)]
 
             # Return an empty string if falsy, with two exceptions
             # 0 should return 0, and False should return False


### PR DESCRIPTION
`_asdict` is not public API for `namedtuple`.

You may want to consider using the built-in `string` module, which
implements this kind of `.0`/`.foo` formatting.