### PR TITLE
Make type checks of scope search more restrictive

### DIFF
--- a/test_spec.py
+++ b/test_spec.py
@@ -466,6 +466,32 @@ class ExpandedCoverage(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    # Regression test for
+    # https://github.com/noahmorrison/chevron/issues/104
+    def test_string_method_names_in_sections_1(self):
+        args = {
+            'template': '{{#upper}}{{{.}}} == {{{upper}}}{{/upper}}',
+            'data': {'upper': 'foo'},
+        }
+
+        result = chevron.render(**args)
+        expected = 'foo == foo'
+        self.assertEqual(result, expected)
+
+    # Another regression test for
+    # https://github.com/noahmorrison/chevron/issues/104
+    def test_string_method_names_in_sections_2(self):
+        args = {
+            'template': (
+                '{{#a}}{{#b}}{{{b}}} '
+                '{{#upper}}{{{upper}}}{{/upper}}{{/b}}{{/a}}'
+            ),
+            'data': {'a': [{'upper': 'foo', 'b': 'x'}]},
+        }
+        result = chevron.render(**args)
+        expected = 'x foo'
+        self.assertEqual(result, expected)
+
     def test_get_key_not_in_dunder_dict_returns_attribute(self):
         class C:
             foo = "bar"


### PR DESCRIPTION
When encountering a scope that is a `str`, we should not call `getattr()` on it and make a ducktyped check if it's actually a complex type. This could also return references to builtin functions of `str`, which in turn will cause unexpected behaviour downstream.

This PR fixes issue #104 .
