### PR TITLE
Support custom python object serialization

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -130,7 +130,7 @@ g_token_cache = {}
 
 def render(template='', data={}, partials_path='.', partials_ext='mustache',
            partials_dict={}, padding='', def_ldel='{{', def_rdel='}}',
-           scopes=None, warn=False, keep=False):
+           scopes=None, warn=False, keep=False, serializer=str):
     """Render a mustache template.
 
     Renders a mustache template with a data scope and partial capability.
@@ -178,6 +178,8 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
     warn          -- Issue a warning to stderr when a template substitution isn't found in the data
 
     keep          -- Keep unreplaced tags when a template substitution isn't found in the data
+
+    serializer    -- Python data serializer (str by default)
 
 
     Returns:
@@ -237,7 +239,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
                 # then get the un-coerced object (next in the stack)
                 thing = scopes[1]
             if not isinstance(thing, unicode_type):
-                thing = unicode(str(thing), 'utf-8')
+                thing = unicode(serializer(thing), 'utf-8')
             output += _html_escape(thing)
 
         # If we're a no html escape tag
@@ -245,7 +247,7 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
             # Just lookup the key and add it
             thing = _get_key(key, scopes, warn=warn, keep=keep, def_ldel=def_ldel, def_rdel=def_rdel)
             if not isinstance(thing, unicode_type):
-                thing = unicode(str(thing), 'utf-8')
+                thing = unicode(serializer(thing), 'utf-8')
             output += thing
 
         # If we're a section tag

--- a/test_spec.py
+++ b/test_spec.py
@@ -552,6 +552,21 @@ class ExpandedCoverage(unittest.TestCase):
         expected = '1st {{ missing_key }} 3rd'
         self.assertEqual(result, expected)
 
+    def test_custom_serializer(self):
+        args = {
+            'template': '{{ value }}',
+            'data': {
+                'value': {
+                    'key': None,
+                },
+            },
+            'serializer': json.dumps,
+        }
+
+        result = chevron.render(**args)
+        expected = '{&quot;key&quot;: null}'
+        self.assertEqual(result, expected)
+
 
 # Run unit tests from command line
 if __name__ == "__main__":


### PR DESCRIPTION
Due to security issues we decided to migrate from jinja to mustache and faced some problems with writing custom lambdas. Adding custom serialization of python objects would help a lot.

Toy example, on what is impossible to elegantly achieve now.

- Dictionary data `data = {"text": "text", "datetime": datetime(2000, 1, 1)}` arrives;
- We want to render both date (using custom lambda for example) and JSON representation of the whole dictionary, e.g., `received on 2000-01-01T00:00:00: {"text": "text", "datetime": "2000-01-01T00:00:00" }`;
- Without custom serialization, we would need to pass both `data` itself as `X` and its JSON representation as `Y` to `render` function as follows: `render(data={'X': data, 'Y': json.dumps(data, ...)})` and then use a template `received on {{ X.datetime }}: {{ Y }}`. It is clumsy and requires special server-side pre-processing for every such case;
- Instead, we would like to be able to serialize any data to JSON string and pass it to custom lambdas that will be able to process them accordingly.

Complete example of what we want to achieve:

```
import fast_json
from datetime import datetime
import chevron

def format_dt(text, render):
    params = fast_json.loads(render(text))
    dt = datetime.fromisoformat(params['dt'])
    return dt.strftime(params['format'])

chevron.render(
    '{{#format_dt}}{"dt": "{{ data.dt }}", "format": "%d-%m-%Y"}{{/format_dt}}: {{ data }}',
    data={
        'data': {
            'dt': datetime.now(),
            'text': 'text',
        },
        'format_dt': format_dt,
    },
    serializer=fast_json.dumps,
).replace('&quot;', '"')
```
gives `'03-11-2021: {"dt": "2021-11-03T16:05:29.477125", "text": "text"}'`

instead of `"03-11-2021: {'dt': datetime.datetime(2021, 11, 3, 16, 6, 42, 483261), 'text': 'text'}"` without custom serialization.

