### PR TITLE
Prevent scope lookup from accidentally matching callable builtins

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -67,7 +67,10 @@ def _get_key(key, scopes, warn, keep, def_ldel, def_rdel):
                     scope = scope[child]
                 except (TypeError, AttributeError):
                     try:
-                        scope = getattr(scope, child)
+                        provisional_scope = getattr(scope, child)
+                        if callable(provisional_scope):
+                            raise TypeError('skipping callable')
+                        scope = provisional_scope
                     except (TypeError, AttributeError):
                         # Try as a list
                         scope = scope[int(child)]


### PR DESCRIPTION
Fixes https://github.com/noahmorrison/chevron/issues/117

The current lookup by scope has false positives when the variable in the template coincidentally matches some Python builtin on the type. For example, `{{title}}` matches `str.title` when it shouldn't. This fix detects when the attribute found in the scope is callable and raises an exception to continue as normal. This fix _does not_ break the intended ability to have callable lambdas in the template.

Before the fix:
```python
>>> import chevron ; chevron.render('{{#title}}{{title}} abc{{/title}}', {'title': 'bob'})
'&lt;built-in method title of str object at 0x7f2dadea95f0&gt; abc'
```
(Here, it found a `'title'` attribute on `'bob'` and got messed up.)

After the fix:
```python
>>> import chevron ; chevron.render('{{#title}}{{title}} abc{{/title}}', {'title': 'bob'})
'bob abc'
```

Callable functionality is still working fine:

```python
>>> import chevron ; chevron.render('{{#bar}}{{foo}} abc{{/bar}}', {'foo': 'bob', 'bar': lambda text,render: render("rendered:"+text)})
'rendered:bob abc'
```

The lambda example from the chevron readme still works as before too.