### PR TITLE
Add parameterless callable variables

### DIFF
--- a/chevron/renderer.py
+++ b/chevron/renderer.py
@@ -231,6 +231,9 @@ def render(template='', data={}, partials_path='.', partials_ext='mustache',
         elif tag == 'variable':
             # Add the html escaped key to the output
             thing = _get_key(key, scopes, warn=warn, keep=keep, def_ldel=def_ldel, def_rdel=def_rdel)
+            if isinstance(thing, Callable):
+                # if the variable is a callable function with no arguments (inspired by Mustache.js) get its value.
+                thing = thing()
             if thing is True and key == '.':
                 # if we've coerced into a boolean by accident
                 # (inverted tags do this)

--- a/test_spec.py
+++ b/test_spec.py
@@ -355,6 +355,27 @@ class ExpandedCoverage(unittest.TestCase):
         expected = 'partial content'
 
         self.assertEqual(result, expected)
+    
+    def test_callable_variables(self):
+        '''Test callable variables
+        '''
+
+        def subject():
+            return 'World'
+
+        args = {
+            'template': '{{greeting}} {{subject}}{{emphasis}}',
+            'data': {
+                "greeting": 'Hello',
+                "subject": subject,
+                "emphasis": '!'
+            }
+        }
+
+        result = chevron.render(**args)
+        expected = 'Hello World!'
+
+        self.assertEqual(result, expected)
 
     # https://github.com/noahmorrison/chevron/issues/35
     def test_custom_falsy(self):


### PR DESCRIPTION
In the [Mustache.js](https://github.com/janl/mustache.js#usage) Javascript Library, functions without parameters can be provided instead of static data values.

This feature is in line with the Mustache spec and in addition allows side effects to be triggered at render time that avoids specific [catch 22](https://www.merriam-webster.com/dictionary/catch-22) issues when trying to inject data into templates.

Please see added unit test for usage.

